### PR TITLE
Fix incorrect DST offset calculation

### DIFF
--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetDateTimeMapper.java
@@ -81,7 +81,7 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractVersionableTime
     public Timestamp toNonNullValue(OffsetDateTime value) {
 
         ZoneOffset currentDatabaseZone = databaseZone == null ? getDefaultZoneOffset() : databaseZone;        
-        int adjustment = TimeZone.getDefault().getOffset(value.toEpochSecond()) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
+        int adjustment = TimeZone.getDefault().getOffset(value.toEpochSecond() * MILLIS_IN_SECOND) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
         
         final Timestamp timestamp = new Timestamp((value.toEpochSecond() * MILLIS_IN_SECOND) - adjustment);
         timestamp.setNanos(value.getNano());

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetTimeMapper.java
@@ -88,7 +88,7 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampColumnMapp
     	OffsetDateTime odt = value.atDate(LocalDate.of(1970, 1, 1));
         
     	ZoneOffset currentDatabaseZone = databaseZone == null ? getDefaultZoneOffset() : databaseZone;        
-        int adjustment = TimeZone.getDefault().getOffset(odt.toEpochSecond()) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
+        int adjustment = TimeZone.getDefault().getOffset(odt.toEpochSecond() * MILLIS_IN_SECOND) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
         
         final Timestamp timestamp = new Timestamp((odt.toEpochSecond() * MILLIS_IN_SECOND) - adjustment);
         timestamp.setNanos(value.getNano());

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnZonedDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnZonedDateTimeMapper.java
@@ -81,7 +81,7 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractVersionableTimes
     public Timestamp toNonNullValue(ZonedDateTime value) {
 
         ZoneOffset currentDatabaseZone = databaseZone == null ? getDefaultZoneOffset() : databaseZone;        
-        int adjustment = TimeZone.getDefault().getOffset(value.toEpochSecond()) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
+        int adjustment = TimeZone.getDefault().getOffset(value.toEpochSecond() * MILLIS_IN_SECOND) - (currentDatabaseZone.getTotalSeconds() * MILLIS_IN_SECOND);
         
         final Timestamp timestamp = new Timestamp((value.toEpochSecond() * MILLIS_IN_SECOND) - adjustment);
         timestamp.setNanos(value.getNano());


### PR DESCRIPTION
Today, we stumbled upon a DST bug in our application that could be traced back to a bug in Jadira's usertypes. TimeZone.getOffset takes the number of milliseconds as parameter, but in some cases, seconds were passed instead, resulting in incorrect DST offsets.

This commit fixes the bug.
