### PR TITLE
Use the formatter for outputting values so that the format is guaranteed to be parseable.

### DIFF
--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/StringColumnLocalDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/StringColumnLocalDateTimeMapper.java
@@ -35,6 +35,6 @@ public class StringColumnLocalDateTimeMapper extends AbstractStringColumnMapper<
 
     @Override
     public String toNonNullValue(LocalDateTime value) {
-        return value.toString();
+        return DATETIME_FORMATTER.format(value);
     }
 }


### PR DESCRIPTION
Without this fix, the following code fails:

```
    import org.jadira.usertype.dateandtime.threeten.columnmapper.StringColumnLocalDateTimeMapper;

    final OffsetDateTime withZeroSeconds = OffsetDateTime.now().withSecond(0).withNano(0);
    final LocalDateTime localDateTime = withZeroSeconds.toLocalDateTime();
    final String truncated = localDateTime.toString();
    final LocalDateTime reconst = LocalDateTime.parse(truncated, StringColumnLocalDateTimeMapper.DATETIME_FORMATTER);
```

The reason is that LocalDateTime.toString() truncates zeros.  For example,
the time `12:34:00.000` would be output as simply `12:34` by `LocalDateTime.toString()`.

When using the explicit format in the reciprocal parse routine, it fails.

Note that if you don't specify an explicit format, `LocalDateTime.parse(String)`
is able to parse the result successfully.

I note that the test `TestPersistentOffsetDateTimeAsStringAndStringOffset` uses an example `OffsetDateTime` with the seconds and milliseconds fields set.  I believe that if those were set to zero, the test would fail.  (I didn't verify this myself, as I couldn't build the project out-of-the-box, I think due to requiring various versions of JDKs).
