### PR TITLE
Moneta upgrade

### DIFF
--- a/depmgmt/pom.xml
+++ b/depmgmt/pom.xml
@@ -280,7 +280,7 @@
 			<dependency>
 			    <groupId>org.javamoney</groupId>
 			    <artifactId>moneta</artifactId>
-			    <version>0.8</version>
+			    <version>0.9</version>
 			    <optional>true</optional>
 			</dependency>
 			

--- a/depmgmt/pom.xml
+++ b/depmgmt/pom.xml
@@ -280,7 +280,7 @@
 			<dependency>
 			    <groupId>org.javamoney</groupId>
 			    <artifactId>moneta</artifactId>
-			    <version>0.9</version>
+			    <version>1.0-RC1</version>
 			    <optional>true</optional>
 			</dependency>
 			

--- a/depmgmt/pom.xml
+++ b/depmgmt/pom.xml
@@ -280,7 +280,7 @@
 			<dependency>
 			    <groupId>org.javamoney</groupId>
 			    <artifactId>moneta</artifactId>
-			    <version>1.0-RC1</version>
+			    <version>1.0-RC2</version>
 			    <optional>true</optional>
 			</dependency>
 			

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyAmountAndCurrency.java
@@ -47,9 +47,8 @@ public class PersistentFastMoneyAmountAndCurrency extends AbstractMultiColumnUse
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         BigDecimal amountPart = (BigDecimal) convertedColumns[1];
-        FastMoney money = FastMoney.of(currencyUnitPart, amountPart);
 
-        return money;
+        return FastMoney.of(amountPart, currencyUnitPart);
     }
 
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMajorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMajorAmountAndCurrency.java
@@ -23,7 +23,7 @@ import org.jadira.usertype.moneyandcurrency.moneta.columnmapper.StringColumnCurr
 import org.jadira.usertype.spi.shared.AbstractMultiColumnUserType;
 import org.jadira.usertype.spi.shared.ColumnMapper;
 import org.javamoney.moneta.FastMoney;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 
 /**
  * Persists the minor amount and currency from a FastMoney instance
@@ -46,15 +46,14 @@ public class PersistentFastMoneyMajorAmountAndCurrency extends AbstractMultiColu
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         Long amountMajorPart = (Long) convertedColumns[1];
-        FastMoney money = FastMoney.of(currencyUnitPart, amountMajorPart);
 
-        return money;
+        return FastMoney.of(amountMajorPart, currencyUnitPart);
     }
 
     @Override
     protected Object[] toConvertedColumns(MonetaryAmount value) {
 
-        return new Object[] { value.getCurrency(), MonetaryFunctions.majorPart().apply(value).getNumber().longValue() };
+        return new Object[] { value.getCurrency(), MonetaryUtil.majorPart().apply(value).getNumber().longValue() };
     }
     
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMinorAmountAndCurrency.java
@@ -50,7 +50,7 @@ public class PersistentFastMoneyMinorAmountAndCurrency extends AbstractMultiColu
         
         BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart, currencyUnitPart.getDefaultFractionDigits());
 
-		return FastMoney.of(currencyUnitPart, majorVal);
+		return FastMoney.of(majorVal, currencyUnitPart);
     }
 
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentFastMoneyMinorAmountAndCurrency.java
@@ -37,8 +37,6 @@ public class PersistentFastMoneyMinorAmountAndCurrency extends AbstractMultiColu
 
     private static final String[] PROPERTY_NAMES = new String[]{ "currencyUnit", "amountMinor" };
 	
-	private static final BigDecimal TEN = BigDecimal.valueOf(10L);
-    
 	@Override
 	protected ColumnMapper<?, ?>[] getColumnMappers() {
 		return COLUMN_MAPPERS;
@@ -50,24 +48,18 @@ public class PersistentFastMoneyMinorAmountAndCurrency extends AbstractMultiColu
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         Long amountMinorPart = (Long) convertedColumns[1];
         
-        BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart);
-    	for (int i = 0; i < currencyUnitPart.getDefaultFractionDigits(); i++) {
-    		majorVal = majorVal.divide(TEN);
-    	}
-        FastMoney money = FastMoney.of(currencyUnitPart, majorVal);
+        BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart, currencyUnitPart.getDefaultFractionDigits());
 
-        return money;
+		return FastMoney.of(currencyUnitPart, majorVal);
     }
 
     @Override
     protected Object[] toConvertedColumns(MonetaryAmount value) {
 
     	BigDecimal minorVal = value.getNumber().numberValue(BigDecimal.class);
-    	for (int i = 0; i < value.getCurrency().getDefaultFractionDigits(); i++) {
-    		minorVal = minorVal.divide(TEN);
-    	}
-    	
-        return new Object[] { value.getCurrency(), minorVal };
+		minorVal = minorVal.movePointRight(value.getCurrency().getDefaultFractionDigits());
+
+		return new Object[] { value.getCurrency(), minorVal.longValue() };
     }
     
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyAmountAndCurrency.java
@@ -47,9 +47,8 @@ public class PersistentMoneyAmountAndCurrency extends AbstractMultiColumnUserTyp
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         BigDecimal amountPart = (BigDecimal) convertedColumns[1];
-        Money money = Money.of(currencyUnitPart, amountPart);
 
-        return money;
+        return Money.of(amountPart, currencyUnitPart);
     }
 
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMajorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMajorAmountAndCurrency.java
@@ -23,7 +23,7 @@ import org.jadira.usertype.moneyandcurrency.moneta.columnmapper.StringColumnCurr
 import org.jadira.usertype.spi.shared.AbstractMultiColumnUserType;
 import org.jadira.usertype.spi.shared.ColumnMapper;
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 
 /**
  * Persists the minor amount and currency from a Money instance
@@ -46,15 +46,14 @@ public class PersistentMoneyMajorAmountAndCurrency extends AbstractMultiColumnUs
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         Long amountMajorPart = (Long) convertedColumns[1];
-        Money money = Money.of(currencyUnitPart, amountMajorPart);
 
-        return money;
+        return Money.of(amountMajorPart, currencyUnitPart);
     }
 
     @Override
     protected Object[] toConvertedColumns(MonetaryAmount value) {
 
-        return new Object[] { value.getCurrency(), MonetaryFunctions.majorPart().apply(value).getNumber().longValue() };
+        return new Object[] { value.getCurrency(), MonetaryUtil.majorPart().apply(value).getNumber().longValue() };
     }
     
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMinorAmountAndCurrency.java
@@ -50,7 +50,7 @@ public class PersistentMoneyMinorAmountAndCurrency extends AbstractMultiColumnUs
         
         BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart, currencyUnitPart.getDefaultFractionDigits());
 
-		return Money.of(currencyUnitPart, majorVal);
+		return Money.of(majorVal, currencyUnitPart);
     }
 
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/PersistentMoneyMinorAmountAndCurrency.java
@@ -37,8 +37,6 @@ public class PersistentMoneyMinorAmountAndCurrency extends AbstractMultiColumnUs
 
     private static final String[] PROPERTY_NAMES = new String[]{ "currencyUnit", "amountMinor" };
 	
-	private static final BigDecimal TEN = BigDecimal.valueOf(10L);
-    
 	@Override
 	protected ColumnMapper<?, ?>[] getColumnMappers() {
 		return COLUMN_MAPPERS;
@@ -50,24 +48,18 @@ public class PersistentMoneyMinorAmountAndCurrency extends AbstractMultiColumnUs
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         Long amountMinorPart = (Long) convertedColumns[1];
         
-        BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart);
-    	for (int i = 0; i < currencyUnitPart.getDefaultFractionDigits(); i++) {
-    		majorVal = majorVal.divide(TEN);
-    	}
-        Money money = Money.of(currencyUnitPart, majorVal);
+        BigDecimal majorVal = BigDecimal.valueOf(amountMinorPart, currencyUnitPart.getDefaultFractionDigits());
 
-        return money;
+		return Money.of(currencyUnitPart, majorVal);
     }
 
     @Override
     protected Object[] toConvertedColumns(MonetaryAmount value) {
 
     	BigDecimal minorVal = value.getNumber().numberValue(BigDecimal.class);
-    	for (int i = 0; i < value.getCurrency().getDefaultFractionDigits(); i++) {
-    		minorVal = minorVal.divide(TEN);
-    	}
+		minorVal = minorVal.movePointRight(value.getCurrency().getDefaultFractionDigits());
     	
-        return new Object[] { value.getCurrency(), minorVal };
+        return new Object[] { value.getCurrency(), minorVal.longValue() };
     }
     
     @Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/BigDecimalColumnFastMoneyMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/BigDecimalColumnFastMoneyMapper.java
@@ -33,7 +33,7 @@ public class BigDecimalColumnFastMoneyMapper extends AbstractBigDecimalColumnMap
 
     @Override
     public FastMoney fromNonNullValue(BigDecimal val) {
-        return FastMoney.of(currencyUnit, val);
+        return FastMoney.of(val, currencyUnit);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class BigDecimalColumnFastMoneyMapper extends AbstractBigDecimalColumnMap
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 		
-		return FastMoney.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return FastMoney.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/BigDecimalColumnMoneyMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/BigDecimalColumnMoneyMapper.java
@@ -33,7 +33,7 @@ public class BigDecimalColumnMoneyMapper extends AbstractBigDecimalColumnMapper<
 
     @Override
     public Money fromNonNullValue(BigDecimal val) {
-        return Money.of(currencyUnit, val);
+        return Money.of(val, currencyUnit);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class BigDecimalColumnMoneyMapper extends AbstractBigDecimalColumnMapper<
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 		
-		return Money.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return Money.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMajorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMajorMapper.java
@@ -22,7 +22,7 @@ import javax.money.MonetaryCurrencies;
 import org.jadira.usertype.moneyandcurrency.moneta.util.CurrencyUnitConfigured;
 import org.jadira.usertype.spi.shared.AbstractLongColumnMapper;
 import org.javamoney.moneta.FastMoney;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 
 public class LongColumnFastMoneyMajorMapper extends AbstractLongColumnMapper<MonetaryAmount> implements CurrencyUnitConfigured {
 
@@ -32,7 +32,7 @@ public class LongColumnFastMoneyMajorMapper extends AbstractLongColumnMapper<Mon
 
     @Override
     public FastMoney fromNonNullValue(Long val) {
-        return FastMoney.of(currencyUnit, val);
+        return FastMoney.of(val, currencyUnit);
     }
 
     @Override
@@ -40,7 +40,7 @@ public class LongColumnFastMoneyMajorMapper extends AbstractLongColumnMapper<Mon
     	if (!currencyUnit.equals(value.getCurrency())) {
     		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrency());
     	}
-        return MonetaryFunctions.majorPart().apply(value).getNumber().longValue();
+        return MonetaryUtil.majorPart().apply(value).getNumber().longValue();
     }
 
 	@Override
@@ -51,7 +51,7 @@ public class LongColumnFastMoneyMajorMapper extends AbstractLongColumnMapper<Mon
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 		
-		return FastMoney.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return FastMoney.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMinorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMinorMapper.java
@@ -35,7 +35,7 @@ public class LongColumnFastMoneyMinorMapper extends AbstractLongColumnMapper<Mon
     public FastMoney fromNonNullValue(Long val) {
     	
     	BigDecimal minorVal = BigDecimal.valueOf(val, currencyUnit.getDefaultFractionDigits());
-    	return FastMoney.of(currencyUnit, minorVal);
+    	return FastMoney.of(minorVal, currencyUnit);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class LongColumnFastMoneyMinorMapper extends AbstractLongColumnMapper<Mon
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 		
-		return FastMoney.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return FastMoney.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMinorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnFastMoneyMinorMapper.java
@@ -24,23 +24,17 @@ import javax.money.MonetaryCurrencies;
 import org.jadira.usertype.moneyandcurrency.moneta.util.CurrencyUnitConfigured;
 import org.jadira.usertype.spi.shared.AbstractLongColumnMapper;
 import org.javamoney.moneta.FastMoney;
-import org.javamoney.moneta.function.MonetaryFunctions;
 
 public class LongColumnFastMoneyMinorMapper extends AbstractLongColumnMapper<MonetaryAmount> implements CurrencyUnitConfigured {
 
     private static final long serialVersionUID = 4205713919952452881L;
 
-	private static final BigDecimal TEN = BigDecimal.valueOf(10L);
-	
     private CurrencyUnit currencyUnit;
 
     @Override
     public FastMoney fromNonNullValue(Long val) {
     	
-    	BigDecimal minorVal = BigDecimal.valueOf(val);
-    	for (int i = 0; i < currencyUnit.getDefaultFractionDigits(); i++) {
-    		minorVal = minorVal.divide(TEN);
-    	}
+    	BigDecimal minorVal = BigDecimal.valueOf(val, currencyUnit.getDefaultFractionDigits());
     	return FastMoney.of(currencyUnit, minorVal);
     }
 
@@ -49,13 +43,9 @@ public class LongColumnFastMoneyMinorMapper extends AbstractLongColumnMapper<Mon
     	if (!currencyUnit.equals(value.getCurrency())) {
     		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrency());
     	}
-        BigDecimal val = MonetaryFunctions.majorPart().apply(value).getNumber().numberValue(BigDecimal.class);
-    	for (int i = 0; i < currencyUnit.getDefaultFractionDigits(); i++) {
-    		val = val.multiply(TEN);
-    	}
-    	val.add(MonetaryFunctions.minorPart().apply(value).getNumber().numberValue(BigDecimal.class));
+		BigDecimal val = value.getNumber().numberValue(BigDecimal.class);
     	
-    	return val.longValue();
+    	return val.movePointRight(currencyUnit.getDefaultFractionDigits()).longValue();
     }
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMajorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMajorMapper.java
@@ -22,7 +22,7 @@ import javax.money.MonetaryCurrencies;
 import org.jadira.usertype.moneyandcurrency.moneta.util.CurrencyUnitConfigured;
 import org.jadira.usertype.spi.shared.AbstractLongColumnMapper;
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 
 public class LongColumnMoneyMajorMapper extends AbstractLongColumnMapper<MonetaryAmount> implements CurrencyUnitConfigured {
 
@@ -32,7 +32,7 @@ public class LongColumnMoneyMajorMapper extends AbstractLongColumnMapper<Monetar
 
     @Override
     public Money fromNonNullValue(Long val) {
-        return Money.of(currencyUnit, val);
+        return Money.of(val, currencyUnit);
     }
 
     @Override
@@ -40,7 +40,7 @@ public class LongColumnMoneyMajorMapper extends AbstractLongColumnMapper<Monetar
     	if (!currencyUnit.equals(value.getCurrency())) {
     		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrency());
     	}
-        return MonetaryFunctions.majorPart().apply(value).getNumber().longValue();
+        return MonetaryUtil.majorPart().apply(value).getNumber().longValue();
     }
 
 	@Override
@@ -51,7 +51,7 @@ public class LongColumnMoneyMajorMapper extends AbstractLongColumnMapper<Monetar
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 		
-		return Money.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return Money.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMinorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMinorMapper.java
@@ -34,7 +34,7 @@ public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<Monetar
     @Override
     public Money fromNonNullValue(Long val) {
     	BigDecimal minorVal = BigDecimal.valueOf(val, currencyUnit.getDefaultFractionDigits());
-    	return Money.of(currencyUnit, minorVal);
+    	return Money.of(minorVal, currencyUnit);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<Monetar
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
 
-		return Money.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
+		return Money.of(Long.parseLong(value), MonetaryCurrencies.getCurrency(currency));
 	}
 
 	@Override

--- a/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMinorMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/moneyandcurrency/moneta/columnmapper/LongColumnMoneyMinorMapper.java
@@ -24,23 +24,16 @@ import javax.money.MonetaryCurrencies;
 import org.jadira.usertype.moneyandcurrency.moneta.util.CurrencyUnitConfigured;
 import org.jadira.usertype.spi.shared.AbstractLongColumnMapper;
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.function.MonetaryFunctions;
 
 public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<MonetaryAmount> implements CurrencyUnitConfigured {
 
     private static final long serialVersionUID = 4205713919952452881L;
 
-	private static final BigDecimal TEN = BigDecimal.valueOf(10L);
-	
     private CurrencyUnit currencyUnit;
 
     @Override
     public Money fromNonNullValue(Long val) {
-    	
-    	BigDecimal minorVal = BigDecimal.valueOf(val);
-    	for (int i = 0; i < currencyUnit.getDefaultFractionDigits(); i++) {
-    		minorVal = minorVal.divide(TEN);
-    	}
+    	BigDecimal minorVal = BigDecimal.valueOf(val, currencyUnit.getDefaultFractionDigits());
     	return Money.of(currencyUnit, minorVal);
     }
 
@@ -49,23 +42,19 @@ public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<Monetar
     	if (!currencyUnit.equals(value.getCurrency())) {
     		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrency());
     	}
-        BigDecimal val = MonetaryFunctions.majorPart().apply(value).getNumber().numberValue(BigDecimal.class);
-    	for (int i = 0; i < currencyUnit.getDefaultFractionDigits(); i++) {
-    		val = val.multiply(TEN);
-    	}
-    	val.add(MonetaryFunctions.minorPart().apply(value).getNumber().numberValue(BigDecimal.class));
-    	
-    	return val.longValue();
+        BigDecimal val = value.getNumber().numberValue(BigDecimal.class);
+
+    	return val.movePointRight(currencyUnit.getDefaultFractionDigits()).longValue();
     }
 
 	@Override
 	public Money fromNonNullString(String s) {
-		
+
 		int separator = s.indexOf(' ');
-		
+
 		String currency = s.substring(0, separator);
 		String value = s.substring(separator + 1);
-		
+
 		return Money.of(MonetaryCurrencies.getCurrency(currency), Long.parseLong(value));
 	}
 
@@ -73,7 +62,7 @@ public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<Monetar
 	public String toNonNullString(MonetaryAmount value) {
 		return value.toString();
 	}
-	
+
 	@Override
     public void setCurrencyUnit(CurrencyUnit currencyUnit) {
         this.currencyUnit = currencyUnit;

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestMonetaMoneySuite.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestMonetaMoneySuite.java
@@ -12,6 +12,12 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses(value = { 
 		TestPersistentCurrencyUnit.class,
+        TestPersistentMoneyAmount.class,
+        TestPersistentMoneyAmountAndCurrency.class,
+        TestPersistentMoneyMajorAmount.class,
+        TestPersistentMoneyMajorAmountAndCurrency.class,
+        TestPersistentMoneyMinorAmount.class,
+        TestPersistentMoneyMinorAmountAndCurrency.class
 })
 public class TestMonetaMoneySuite {
 

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmount.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmount.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 
 public class TestPersistentMoneyAmount extends AbstractDatabaseTest<MoneyAmountHolder> {
 
-    private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("USD", new BigDecimal("0.99")), null};
+    private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "USD"), null};
 
     public TestPersistentMoneyAmount() {
     	super(TestMonetaMoneySuite.getFactory());

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmount.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmount.java
@@ -15,16 +15,14 @@
  */
 package org.jadira.usertype.moneyandcurrency.moneta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.math.BigDecimal;
 
 import org.jadira.usertype.dateandtime.shared.dbunit.AbstractDatabaseTest;
 import org.jadira.usertype.moneyandcurrency.moneta.testmodel.MoneyAmountHolder;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TestPersistentMoneyAmount extends AbstractDatabaseTest<MoneyAmountHolder> {
 
@@ -55,7 +53,7 @@ public class TestPersistentMoneyAmount extends AbstractDatabaseTest<MoneyAmountH
             if (moneys[i] == null) {
                 assertNull(item.getMoney());
             } else {
-                assertEquals(moneys[i].toString(), item.getMoney().toString());
+                assertTrue(moneys[i].isEqualTo(item.getMoney()));
             }
         }
 

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmountAndCurrency.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyAmountAndCurrency.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class TestPersistentMoneyAmountAndCurrency extends AbstractDatabaseTest<MoneyAmountAndCurrencyHolder> {
 
-	private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("EUR", new BigDecimal("0.99")), Money.of("EUR", new BigDecimal("-0.99")), null};
+	private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "EUR"), Money.of(new BigDecimal("-0.99"), "EUR"), null};
 
     public TestPersistentMoneyAmountAndCurrency() {
     	super(TestMonetaMoneySuite.getFactory());

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMajorAmount.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMajorAmount.java
@@ -24,12 +24,12 @@ import java.math.BigDecimal;
 import org.jadira.usertype.dateandtime.shared.dbunit.AbstractDatabaseTest;
 import org.jadira.usertype.moneyandcurrency.moneta.testmodel.MoneyMajorAmountHolder;
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Test;
 
 public class TestPersistentMoneyMajorAmount extends AbstractDatabaseTest<MoneyMajorAmountHolder> {
 
-	private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("USD", new BigDecimal("0.99")), null};
+	private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "USD"), null};
 	
     public TestPersistentMoneyMajorAmount() {
     	super(TestMonetaMoneySuite.getFactory());
@@ -55,7 +55,7 @@ public class TestPersistentMoneyMajorAmount extends AbstractDatabaseTest<MoneyMa
             if (moneys[i] == null) {
                 assertNull(item.getMoney());
             } else {
-                assertEquals(MonetaryFunctions.majorPart().apply(moneys[i]).toString(), item.getMoney().toString());
+                assertEquals(MonetaryUtil.majorPart().apply(moneys[i]).toString(), item.getMoney().toString());
             }
         }
 

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMajorAmountAndCurrency.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMajorAmountAndCurrency.java
@@ -24,12 +24,12 @@ import java.math.BigDecimal;
 import org.jadira.usertype.dateandtime.shared.dbunit.AbstractDatabaseTest;
 import org.jadira.usertype.moneyandcurrency.moneta.testmodel.MoneyMajorAmountAndCurrencyHolder;
 import org.javamoney.moneta.Money;
-import org.javamoney.moneta.function.MonetaryFunctions;
+import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Test;
 
 public class TestPersistentMoneyMajorAmountAndCurrency extends AbstractDatabaseTest<MoneyMajorAmountAndCurrencyHolder> {
 
-	private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("EUR", new BigDecimal("0.99")), Money.of("EUR", new BigDecimal("-0.99")), null};
+	private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "EUR"), Money.of(new BigDecimal("-0.99"), "EUR"), null};
 
     public TestPersistentMoneyMajorAmountAndCurrency() {
     	super(TestMonetaMoneySuite.getFactory());
@@ -57,7 +57,7 @@ public class TestPersistentMoneyMajorAmountAndCurrency extends AbstractDatabaseT
             if (moneys[i] == null) {
                 assertNull(item.getMoney());
             } else {
-                assertEquals(MonetaryFunctions.majorPart().apply(moneys[i]).toString(), item.getMoney().toString());
+                assertEquals(MonetaryUtil.majorPart().apply(moneys[i]).toString(), item.getMoney().toString());
             }
         }
 

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmount.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmount.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 
 public class TestPersistentMoneyMinorAmount extends AbstractDatabaseTest<MoneyMinorAmountHolder> {
 
-	private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("USD", new BigDecimal("0.99")), null};
+	private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "USD"), null};
 	
     public TestPersistentMoneyMinorAmount() {
     	super(TestMonetaMoneySuite.getFactory());

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmount.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmount.java
@@ -15,16 +15,14 @@
  */
 package org.jadira.usertype.moneyandcurrency.moneta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.math.BigDecimal;
 
 import org.jadira.usertype.dateandtime.shared.dbunit.AbstractDatabaseTest;
 import org.jadira.usertype.moneyandcurrency.moneta.testmodel.MoneyMinorAmountHolder;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TestPersistentMoneyMinorAmount extends AbstractDatabaseTest<MoneyMinorAmountHolder> {
 
@@ -55,7 +53,7 @@ public class TestPersistentMoneyMinorAmount extends AbstractDatabaseTest<MoneyMi
             if (moneys[i] == null) {
                 assertNull(item.getMoney());
             } else {
-                assertEquals(moneys[i].toString(), item.getMoney().toString());
+                assertTrue(moneys[i].isEqualTo(item.getMoney()));
             }
         }
 

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmountAndCurrency.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 
 public class TestPersistentMoneyMinorAmountAndCurrency extends AbstractDatabaseTest<MoneyMinorAmountAndCurrencyHolder> {
 
-	private static final Money[] moneys = new Money[]{ Money.of("USD", BigDecimal.valueOf(100)), Money.of("USD", new BigDecimal("100.10")), Money.of("EUR", new BigDecimal("0.99")), Money.of("EUR", new BigDecimal("-0.99")), null};
+	private static final Money[] moneys = new Money[]{ Money.of(BigDecimal.valueOf(100), "USD"), Money.of(new BigDecimal("100.10"), "USD"), Money.of(new BigDecimal("0.99"), "EUR"), Money.of(new BigDecimal("-0.99"), "EUR"), null};
 
     public TestPersistentMoneyMinorAmountAndCurrency() {
     	super(TestMonetaMoneySuite.getFactory());

--- a/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmountAndCurrency.java
+++ b/usertype.extended/src/test/java/org/jadira/usertype/moneyandcurrency/moneta/TestPersistentMoneyMinorAmountAndCurrency.java
@@ -15,16 +15,14 @@
  */
 package org.jadira.usertype.moneyandcurrency.moneta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.math.BigDecimal;
 
 import org.jadira.usertype.dateandtime.shared.dbunit.AbstractDatabaseTest;
 import org.jadira.usertype.moneyandcurrency.moneta.testmodel.MoneyMinorAmountAndCurrencyHolder;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TestPersistentMoneyMinorAmountAndCurrency extends AbstractDatabaseTest<MoneyMinorAmountAndCurrencyHolder> {
 
@@ -54,7 +52,7 @@ public class TestPersistentMoneyMinorAmountAndCurrency extends AbstractDatabaseT
             if (moneys[i] == null) {
                 assertNull(item.getMoney());
             } else {
-                assertEquals(moneys[i].toString(), item.getMoney().toString());
+                assertTrue(moneys[i].isEqualTo(item.getMoney()));
             }
         }
 


### PR DESCRIPTION
Upgraded moneta to version 1.0-RC1. Mainly swapped arguments of `Money.of()` and replaced `MonetaryFunctions.majorPart()` with `MonetaryUtil.majorPart()`.