### PR TITLE
Now using a Zone ID instead of Offset. Also changed ZonedDateTimeMapp…

### DIFF
--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/AbstractTimestampThreeTenBPColumnMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/AbstractTimestampThreeTenBPColumnMapper.java
@@ -22,28 +22,28 @@ import java.util.TimeZone;
 import org.jadira.usertype.spi.shared.AbstractVersionableTimestampColumnMapper;
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.jadira.usertype.spi.shared.DstSafeTimestampType;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 
-public abstract class AbstractTimestampThreeTenBPColumnMapper<T> extends AbstractVersionableTimestampColumnMapper<T> implements DatabaseZoneConfigured<ZoneOffset> {
+public abstract class AbstractTimestampThreeTenBPColumnMapper<T> extends AbstractVersionableTimestampColumnMapper<T> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 	
-    private ZoneOffset databaseZone = ZoneOffset.of("Z");
+    private ZoneId databaseZone = ZoneId.of("Z");
     
 	public AbstractTimestampThreeTenBPColumnMapper() {
 	}
 
-	public AbstractTimestampThreeTenBPColumnMapper(ZoneOffset databaseZone) {
+	public AbstractTimestampThreeTenBPColumnMapper(ZoneId databaseZone) {
 		this.databaseZone = databaseZone;
 	}
 
     
     @Override
-    public void setDatabaseZone(ZoneOffset databaseZone) {
+    public void setDatabaseZone(ZoneId databaseZone) {
         this.databaseZone = databaseZone;
     }
 
-    protected ZoneOffset getDatabaseZone() {
+    protected ZoneId getDatabaseZone() {
         return databaseZone;
     }
 	
@@ -62,7 +62,7 @@ public abstract class AbstractTimestampThreeTenBPColumnMapper<T> extends Abstrac
     	return new DstSafeTimestampType(cal);
     }
 
-	private Calendar resolveCalendar(ZoneOffset databaseZone) {
+	private Calendar resolveCalendar(ZoneId databaseZone) {
 		
 		String id = databaseZone.getId();
 		if (Arrays.binarySearch(TimeZone.getAvailableIDs(), id) != -1) {

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnInstantMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnInstantMapper.java
@@ -19,12 +19,12 @@ import java.sql.Timestamp;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
 
-public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenBPColumnMapper<Instant> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenBPColumnMapper<Instant> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -34,7 +34,7 @@ public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenBPCol
 		super();
 	}
 
-	public TimestampColumnInstantMapper(ZoneOffset databaseZone) {
+	public TimestampColumnInstantMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -66,7 +66,7 @@ public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenBPCol
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}	
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnLocalDateTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnLocalDateTimeMapper.java
@@ -20,13 +20,13 @@ import java.sql.Timestamp;
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
 
-public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<LocalDateTime> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<LocalDateTime> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
     
@@ -36,7 +36,7 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
 		super();
 	}
 
-	public TimestampColumnLocalDateTimeMapper(ZoneOffset databaseZone) {
+	public TimestampColumnLocalDateTimeMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -48,7 +48,7 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public LocalDateTime fromNonNullValue(Timestamp value) {
     	
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
         
         Instant instant = Instant.ofEpochMilli(value.getTime());
         instant = instant.with(ChronoField.NANO_OF_SECOND, value.getNanos());
@@ -64,7 +64,7 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public Timestamp toNonNullValue(LocalDateTime value) {
 
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
     	
     	ZonedDateTime zdt = value.atZone(currentDatabaseZone);
         
@@ -73,32 +73,32 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
         return timestamp;
     }
     
-    private static ZoneOffset getDefault() {
+    private static ZoneId getDefault() {
 
-    	ZoneOffset zone = null;
+    	ZoneId zone = null;
         try {
             try {
                 String id = System.getProperty("user.timezone");
                 if (id != null) {
-                    zone = ZoneOffset.of(id);
+                    zone = ZoneId.of(id);
                 }
             } catch (RuntimeException ex) {
                 zone = null;
             }
             if (zone == null) {
-                zone = ZoneOffset.of(java.util.TimeZone.getDefault().getID());
+                zone = ZoneId.of(java.util.TimeZone.getDefault().getID());
             }
         } catch (RuntimeException ex) {
             zone = null;
         }
         if (zone == null) {
-            zone = ZoneOffset.of("Z");
+            zone = ZoneId.of("Z");
         }
         return zone;
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnLocalTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnLocalTimeMapper.java
@@ -24,13 +24,13 @@ import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.LocalTime;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
 
-public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<LocalTime> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<LocalTime> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = 1921591625617366103L;
 
@@ -43,7 +43,7 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenBPC
 		super(null);
 	}
 
-	public TimestampColumnLocalTimeMapper(ZoneOffset databaseZone) {
+	public TimestampColumnLocalTimeMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -70,13 +70,13 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenBPC
     @Override
     public Timestamp toNonNullValue(LocalTime value) {
 
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();        
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();        
     	
     	LocalDateTime ldt = value.atDate(LocalDate.of(1970, 1, 1));
     	ZonedDateTime zdt = ldt.atZone(currentDatabaseZone);
         Instant ins = zdt.toInstant();
 
-    	ZoneOffset off = getDefault();
+    	ZoneId off = getDefault();
         int adjustment = TimeZone.getDefault().getOffset(ins.toEpochMilli()) - (off.getRules().getOffset(LocalDateTime.now()).getTotalSeconds() * MILLIS_IN_SECOND);
         
         final Timestamp timestamp = new Timestamp(ins.toEpochMilli() - adjustment);
@@ -84,32 +84,32 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenBPC
         return timestamp;
     }
 
-    private static ZoneOffset getDefault() {
+    private static ZoneId getDefault() {
 
-    	ZoneOffset zone = null;
+    	ZoneId zone = null;
         try {
             try {
                 String id = System.getProperty("user.timezone");
                 if (id != null) {
-                    zone = ZoneOffset.of(id);
+                    zone = ZoneId.of(id);
                 }
             } catch (RuntimeException ex) {
                 zone = null;
             }
             if (zone == null) {
-                zone = ZoneOffset.of(java.util.TimeZone.getDefault().getID());
+                zone = ZoneId.of(java.util.TimeZone.getDefault().getID());
             }
         } catch (RuntimeException ex) {
             zone = null;
         }
         if (zone == null) {
-            zone = ZoneOffset.of("Z");
+            zone = ZoneId.of("Z");
         }
         return zone;
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnMonthDayMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnMonthDayMapper.java
@@ -17,18 +17,17 @@ package org.jadira.usertype.dateandtime.threetenbp.columnmapper;
 
 import java.sql.Timestamp;
 
-import org.jadira.usertype.dateandtime.threetenbp.columnmapper.AbstractTimestampThreeTenBPColumnMapper;
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.MonthDay;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
 
-public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPColumnMapper<MonthDay> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPColumnMapper<MonthDay> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
     
@@ -38,7 +37,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPCo
 		super();
 	}
 
-	public TimestampColumnMonthDayMapper(ZoneOffset databaseZone) {
+	public TimestampColumnMonthDayMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -50,7 +49,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPCo
     @Override
     public MonthDay fromNonNullValue(Timestamp value) {
     	
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
         
         Instant instant = Instant.ofEpochMilli(value.getTime());
         instant = instant.with(ChronoField.NANO_OF_SECOND, value.getNanos());
@@ -69,7 +68,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPCo
 
         LocalDateTime ldt = LocalDateTime.of(1970, value.getMonthValue(), value.getDayOfMonth(), 0, 0);
         
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
     	
     	ZonedDateTime zdt = ldt.atZone(currentDatabaseZone);
         
@@ -77,32 +76,32 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenBPCo
         return timestamp;
     }
     
-    private static ZoneOffset getDefault() {
+    private static ZoneId getDefault() {
 
-    	ZoneOffset zone = null;
+    	ZoneId zone = null;
         try {
             try {
                 String id = System.getProperty("user.timezone");
                 if (id != null) {
-                    zone = ZoneOffset.of(id);
+                    zone = ZoneId.of(id);
                 }
             } catch (RuntimeException ex) {
                 zone = null;
             }
             if (zone == null) {
-                zone = ZoneOffset.of(java.util.TimeZone.getDefault().getID());
+                zone = ZoneId.of(java.util.TimeZone.getDefault().getID());
             }
         } catch (RuntimeException ex) {
             zone = null;
         }
         if (zone == null) {
-            zone = ZoneOffset.of("Z");
+            zone = ZoneId.of("Z");
         }
         return zone;
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetDateTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetDateTimeMapper.java
@@ -15,7 +15,7 @@
  */
 package org.jadira.usertype.dateandtime.threetenbp.columnmapper;
 
-import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneOffset;
+import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneId;
 
 import java.sql.Timestamp;
 
@@ -23,7 +23,7 @@ import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.jadira.usertype.spi.shared.JavaZoneConfigured;
 import org.threeten.bp.Instant;
 import org.threeten.bp.OffsetDateTime;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
@@ -31,7 +31,7 @@ import org.threeten.bp.temporal.ChronoField;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<OffsetDateTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<OffsetDateTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -39,13 +39,13 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnOffsetDateTimeMapper() {
 		super();
 	}
 
-	public TimestampColumnOffsetDateTimeMapper(ZoneOffset databaseZone, ZoneOffset javaZone) {
+	public TimestampColumnOffsetDateTimeMapper(ZoneId databaseZone, ZoneId javaZone) {
 		super(databaseZone);
 		this.javaZone = javaZone;
 	}
@@ -58,11 +58,11 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
     @Override
     public OffsetDateTime fromNonNullValue(Timestamp value) {
 
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneId() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneId() : javaZone;
 
         OffsetDateTime dateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
-        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withOffsetSameInstant(currentJavaZone);
+        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).atZoneSameInstant(currentJavaZone).toOffsetDateTime();
         
         return dateTime;
     }
@@ -81,12 +81,12 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
     }
     
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnOffsetTimeMapper.java
@@ -15,7 +15,7 @@
  */
 package org.jadira.usertype.dateandtime.threetenbp.columnmapper;
 
-import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneOffset;
+import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneId;
 
 import java.sql.Timestamp;
 
@@ -25,7 +25,7 @@ import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.OffsetTime;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.temporal.ChronoField;
@@ -33,7 +33,7 @@ import org.threeten.bp.temporal.ChronoField;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<OffsetTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<OffsetTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -42,13 +42,13 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenBP
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnOffsetTimeMapper() {
 		super();
 	}
 
-	public TimestampColumnOffsetTimeMapper(ZoneOffset databaseZone, ZoneOffset javaZone) {
+	public TimestampColumnOffsetTimeMapper(ZoneId databaseZone, ZoneId javaZone) {
 		super(databaseZone);
 		this.javaZone = javaZone;
 	}
@@ -61,11 +61,11 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenBP
     @Override
     public OffsetTime fromNonNullValue(Timestamp value) {
     	
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneId() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneId() : javaZone;
 
         OffsetDateTime dateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
-        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withOffsetSameInstant(currentJavaZone);
+        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).atZoneSameInstant(currentJavaZone).toOffsetDateTime();
 
         OffsetTime time = dateTime.toOffsetTime();
         return time;
@@ -87,12 +87,12 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenBP
     }
 
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}		
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnZonedDateTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threetenbp/columnmapper/TimestampColumnZonedDateTimeMapper.java
@@ -15,14 +15,14 @@
  */
 package org.jadira.usertype.dateandtime.threetenbp.columnmapper;
 
-import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneOffset;
+import static org.jadira.usertype.dateandtime.threetenbp.utils.ZoneHelper.getDefaultZoneId;
 
 import java.sql.Timestamp;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.jadira.usertype.spi.shared.JavaZoneConfigured;
 import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
@@ -31,7 +31,7 @@ import org.threeten.bp.temporal.ChronoField;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<ZonedDateTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTenBPColumnMapper<ZonedDateTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -39,13 +39,13 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnZonedDateTimeMapper() {
 		super();
 	}
 
-	public TimestampColumnZonedDateTimeMapper(ZoneOffset databaseZone, ZoneOffset javaZone) {
+	public TimestampColumnZonedDateTimeMapper(ZoneId databaseZone, ZoneId javaZone) {
 		super(databaseZone);
 		this.javaZone = javaZone;
 	}
@@ -58,8 +58,8 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public ZonedDateTime fromNonNullValue(Timestamp value) {
 
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneId() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneId() : javaZone;
 
         ZonedDateTime dateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
         dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withZoneSameInstant(currentJavaZone);
@@ -81,12 +81,12 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
     }
     
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/AbstractTimestampThreeTenColumnMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/AbstractTimestampThreeTenColumnMapper.java
@@ -15,6 +15,7 @@
  */
 package org.jadira.usertype.dateandtime.threeten.columnmapper;
 
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -24,26 +25,26 @@ import org.jadira.usertype.spi.shared.AbstractVersionableTimestampColumnMapper;
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 import org.jadira.usertype.spi.shared.DstSafeTimestampType;
 
-public abstract class AbstractTimestampThreeTenColumnMapper<T> extends AbstractVersionableTimestampColumnMapper<T> implements DatabaseZoneConfigured<ZoneOffset> {
+public abstract class AbstractTimestampThreeTenColumnMapper<T> extends AbstractVersionableTimestampColumnMapper<T> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 	
-    private ZoneOffset databaseZone = ZoneOffset.of("Z");
+    private ZoneId databaseZone = ZoneOffset.of("Z");
     
 	public AbstractTimestampThreeTenColumnMapper() {
 	}
 
-	public AbstractTimestampThreeTenColumnMapper(ZoneOffset databaseZone) {
+	public AbstractTimestampThreeTenColumnMapper(ZoneId databaseZone) {
 		this.databaseZone = databaseZone;
 	}
 
     
     @Override
-    public void setDatabaseZone(ZoneOffset databaseZone) {
+    public void setDatabaseZone(ZoneId databaseZone) {
         this.databaseZone = databaseZone;
     }
 
-    protected ZoneOffset getDatabaseZone() {
+    protected ZoneId getDatabaseZone() {
         return databaseZone;
     }
 	
@@ -62,7 +63,7 @@ public abstract class AbstractTimestampThreeTenColumnMapper<T> extends AbstractV
     	return new DstSafeTimestampType(cal);
     }
 
-	private Calendar resolveCalendar(ZoneOffset databaseZone) {
+	private Calendar resolveCalendar(ZoneId databaseZone) {
 		
 		String id = databaseZone.getId();
 		if (Arrays.binarySearch(TimeZone.getAvailableIDs(), id) != -1) {

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnInstantMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnInstantMapper.java
@@ -17,14 +17,14 @@ package org.jadira.usertype.dateandtime.threeten.columnmapper;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 
-public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenColumnMapper<Instant> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenColumnMapper<Instant> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -34,7 +34,7 @@ public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenColum
 		super();
 	}
 
-	public TimestampColumnInstantMapper(ZoneOffset databaseZone) {
+	public TimestampColumnInstantMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -66,7 +66,7 @@ public class TimestampColumnInstantMapper extends AbstractTimestampThreeTenColum
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}	
 }

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnLocalDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnLocalDateTimeMapper.java
@@ -18,6 +18,7 @@ package org.jadira.usertype.dateandtime.threeten.columnmapper;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -26,7 +27,7 @@ import java.time.temporal.ChronoField;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 
-public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<LocalDateTime> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<LocalDateTime> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
     
@@ -48,7 +49,7 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public LocalDateTime fromNonNullValue(Timestamp value) {
     	
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
         
         Instant instant = Instant.ofEpochMilli(value.getTime());
         instant = instant.with(ChronoField.NANO_OF_SECOND, value.getNanos());
@@ -64,7 +65,7 @@ public class TimestampColumnLocalDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public Timestamp toNonNullValue(LocalDateTime value) {
 
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
     	
     	ZonedDateTime zdt = value.atZone(currentDatabaseZone);
         

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnLocalTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnLocalTimeMapper.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -30,7 +30,7 @@ import java.util.TimeZone;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 
-public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenColumnMapper<LocalTime> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenColumnMapper<LocalTime> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = 1921591625617366103L;
 
@@ -43,7 +43,7 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenCol
 		super(null);
 	}
 
-	public TimestampColumnLocalTimeMapper(ZoneOffset databaseZone) {
+	public TimestampColumnLocalTimeMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -70,13 +70,13 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenCol
     @Override
     public Timestamp toNonNullValue(LocalTime value) {
 
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();        
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();        
     	
     	LocalDateTime ldt = value.atDate(LocalDate.of(1970, 1, 1));
     	ZonedDateTime zdt = ldt.atZone(currentDatabaseZone);
         Instant ins = zdt.toInstant();
 
-    	ZoneOffset off = getDefault();
+    	ZoneId off = getDefault();
         int adjustment = TimeZone.getDefault().getOffset(ins.toEpochMilli()) - (off.getRules().getOffset(LocalDateTime.now()).getTotalSeconds() * MILLIS_IN_SECOND);
         
         final Timestamp timestamp = new Timestamp(ins.toEpochMilli() - adjustment);
@@ -84,32 +84,32 @@ public class TimestampColumnLocalTimeMapper extends AbstractTimestampThreeTenCol
         return timestamp;
     }
 
-    private static ZoneOffset getDefault() {
+    private static ZoneId getDefault() {
 
-    	ZoneOffset zone = null;
+    	ZoneId zone = null;
         try {
             try {
                 String id = System.getProperty("user.timezone");
                 if (id != null) {
-                    zone = ZoneOffset.of(id);
+                    zone = ZoneId.of(id);
                 }
             } catch (RuntimeException ex) {
                 zone = null;
             }
             if (zone == null) {
-                zone = ZoneOffset.of(java.util.TimeZone.getDefault().getID());
+                zone = ZoneId.of(java.util.TimeZone.getDefault().getID());
             }
         } catch (RuntimeException ex) {
             zone = null;
         }
         if (zone == null) {
-            zone = ZoneOffset.of("Z");
+            zone = ZoneId.of("Z");
         }
         return zone;
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnMonthDayMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnMonthDayMapper.java
@@ -19,7 +19,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.MonthDay;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -27,7 +27,7 @@ import java.time.temporal.ChronoField;
 
 import org.jadira.usertype.spi.shared.DatabaseZoneConfigured;
 
-public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColumnMapper<MonthDay> implements DatabaseZoneConfigured<ZoneOffset> {
+public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColumnMapper<MonthDay> implements DatabaseZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
     
@@ -37,7 +37,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColu
 		super();
 	}
 
-	public TimestampColumnMonthDayMapper(ZoneOffset databaseZone) {
+	public TimestampColumnMonthDayMapper(ZoneId databaseZone) {
 		super(databaseZone);
 	}
     
@@ -49,7 +49,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColu
     @Override
     public MonthDay fromNonNullValue(Timestamp value) {
     	
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
         
         Instant instant = Instant.ofEpochMilli(value.getTime());
         instant = instant.with(ChronoField.NANO_OF_SECOND, value.getNanos());
@@ -68,7 +68,7 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColu
 
         LocalDateTime ldt = LocalDateTime.of(1970, value.getMonthValue(), value.getDayOfMonth(), 0, 0);
         
-    	ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
+    	ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefault() : getDatabaseZone();
     	
     	ZonedDateTime zdt = ldt.atZone(currentDatabaseZone);
         
@@ -76,32 +76,32 @@ public class TimestampColumnMonthDayMapper extends AbstractTimestampThreeTenColu
         return timestamp;
     }
     
-    private static ZoneOffset getDefault() {
+    private static ZoneId getDefault() {
 
-    	ZoneOffset zone = null;
+    	ZoneId zone = null;
         try {
             try {
                 String id = System.getProperty("user.timezone");
                 if (id != null) {
-                    zone = ZoneOffset.of(id);
+                    zone = ZoneId.of(id);
                 }
             } catch (RuntimeException ex) {
                 zone = null;
             }
             if (zone == null) {
-                zone = ZoneOffset.of(java.util.TimeZone.getDefault().getID());
+                zone = ZoneId.of(java.util.TimeZone.getDefault().getID());
             }
         } catch (RuntimeException ex) {
             zone = null;
         }
         if (zone == null) {
-            zone = ZoneOffset.of("Z");
+            zone = ZoneId.of("Z");
         }
         return zone;
     }
     
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnOffsetDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnOffsetDateTimeMapper.java
@@ -15,12 +15,13 @@
  */
 package org.jadira.usertype.dateandtime.threeten.columnmapper;
 
-import static org.jadira.usertype.dateandtime.threeten.utils.ZoneHelper.getDefaultZoneOffset;
+import static org.jadira.usertype.dateandtime.threeten.utils.ZoneHelper.getDefaultZoneId;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -31,7 +32,7 @@ import org.jadira.usertype.spi.shared.JavaZoneConfigured;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<OffsetDateTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<OffsetDateTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -39,13 +40,13 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnOffsetDateTimeMapper() {
 		super();
 	}
 
-	public TimestampColumnOffsetDateTimeMapper(ZoneOffset databaseZone, ZoneOffset javaZone) {
+	public TimestampColumnOffsetDateTimeMapper(ZoneId databaseZone, ZoneId javaZone) {
 		super(databaseZone);
 		this.javaZone = javaZone;
 	}
@@ -58,11 +59,12 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
     @Override
     public OffsetDateTime fromNonNullValue(Timestamp value) {
 
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneId() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneId() : javaZone;
 
         OffsetDateTime dateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
-        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withOffsetSameInstant(currentJavaZone);
+        ZonedDateTime zonedDateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).atZoneSameInstant(currentJavaZone);
+        dateTime = zonedDateTime.toOffsetDateTime();
         
         return dateTime;
     }
@@ -81,12 +83,12 @@ public class TimestampColumnOffsetDateTimeMapper extends AbstractTimestampThreeT
     }
     
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnOffsetTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnOffsetTimeMapper.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -33,7 +34,7 @@ import org.jadira.usertype.spi.shared.JavaZoneConfigured;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenColumnMapper<OffsetTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenColumnMapper<OffsetTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -42,7 +43,7 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenCo
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnOffsetTimeMapper() {
 		super();
@@ -61,11 +62,11 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenCo
     @Override
     public OffsetTime fromNonNullValue(Timestamp value) {
     	
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
 
         OffsetDateTime dateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
-        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withOffsetSameInstant(currentJavaZone);
+        dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).atZoneSameInstant(currentJavaZone).toOffsetDateTime();
 
         OffsetTime time = dateTime.toOffsetTime();
         return time;
@@ -87,7 +88,7 @@ public class TimestampColumnOffsetTimeMapper extends AbstractTimestampThreeTenCo
     }
 
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         

--- a/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnZonedDateTimeMapper.java
+++ b/usertype.extended/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimestampColumnZonedDateTimeMapper.java
@@ -15,11 +15,11 @@
  */
 package org.jadira.usertype.dateandtime.threeten.columnmapper;
 
-import static org.jadira.usertype.dateandtime.threeten.utils.ZoneHelper.getDefaultZoneOffset;
+import static org.jadira.usertype.dateandtime.threeten.utils.ZoneHelper.getDefaultZoneId;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -31,7 +31,7 @@ import org.jadira.usertype.spi.shared.JavaZoneConfigured;
 /**
  * Maps a precise datetime column for storage. The UTC Zone will be used to store the value
  */
-public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<ZonedDateTime> implements DatabaseZoneConfigured<ZoneOffset>, JavaZoneConfigured<ZoneOffset> {
+public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTenColumnMapper<ZonedDateTime> implements DatabaseZoneConfigured<ZoneId>, JavaZoneConfigured<ZoneId> {
 
     private static final long serialVersionUID = -7670411089210984705L;
 
@@ -39,13 +39,13 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
 
 	private static final int MILLIS_IN_SECOND = 1000;
 
-    private ZoneOffset javaZone = null;
+    private ZoneId javaZone = null;
 
 	public TimestampColumnZonedDateTimeMapper() {
 		super();
 	}
 
-	public TimestampColumnZonedDateTimeMapper(ZoneOffset databaseZone, ZoneOffset javaZone) {
+	public TimestampColumnZonedDateTimeMapper(ZoneId databaseZone, ZoneId javaZone) {
 		super(databaseZone);
 		this.javaZone = javaZone;
 	}
@@ -58,8 +58,8 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
     @Override
     public ZonedDateTime fromNonNullValue(Timestamp value) {
 
-        ZoneOffset currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneOffset() : getDatabaseZone();
-        ZoneOffset currentJavaZone = javaZone == null ? getDefaultZoneOffset() : javaZone;
+        ZoneId currentDatabaseZone = getDatabaseZone() == null ? getDefaultZoneId() : getDatabaseZone();
+        ZoneId currentJavaZone = javaZone == null ? getDefaultZoneId() : javaZone;
 
         ZonedDateTime dateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(value.getTime()), currentDatabaseZone);
         dateTime = dateTime.with(ChronoField.NANO_OF_SECOND, value.getNanos()).withZoneSameInstant(currentJavaZone);
@@ -81,12 +81,12 @@ public class TimestampColumnZonedDateTimeMapper extends AbstractTimestampThreeTe
     }
     
     @Override
-    public void setJavaZone(ZoneOffset javaZone) {
+    public void setJavaZone(ZoneId javaZone) {
         this.javaZone = javaZone;
     }
         
 	@Override
-	public ZoneOffset parseZone(String zoneString) {
-		return ZoneOffset.of(zoneString);
+	public ZoneId parseZone(String zoneString) {
+		return ZoneId.of(zoneString);
 	}
 }


### PR DESCRIPTION
…er etc.

Applied same type of change as from commit cdd34a301e053958da3fec01595fcea0e25eb9e6 to ZonedDateTime-, OffsetTime-, OffsetDateTime-, MonthDay-, LocalTime-, LocalDateTime-, and InstantMapper since we need to be able to specify database timezone GMT+1, and we use ZonedDateTime in our project.