### PR TITLE
Use different classname to detect Mutability Detector

### DIFF
--- a/cloning/src/main/java/org/jadira/reflection/core/platform/FeatureDetection.java
+++ b/cloning/src/main/java/org/jadira/reflection/core/platform/FeatureDetection.java
@@ -40,7 +40,7 @@ public class FeatureDetection {
 	static {
 		boolean hasMutabilityDetector = true;
 		try {
-			Class.forName("org.mutabilitydetector.ThreadUnsafeAnalysisSession");
+			Class.forName("org.mutabilitydetector.Configurations");
 		} catch (ClassNotFoundException e) {
 			hasMutabilityDetector = false;
 		}


### PR DESCRIPTION
Hi, I'm the author of Mutability Detector. In looking into an [issue raised](https://github.com/MutabilityDetector/MutabilityDetector/issues/82) against MD that relates to Jadira cloning I noticed that the presence of MD is determined by checking for the existence of a class, like so:
```
try {
    Class.forName("org.mutabilitydetector.ThreadUnsafeAnalysisSession");
} catch (ClassNotFoundException e) {
```

This class has recently been removed ([it's now thread safe](https://github.com/MutabilityDetector/MutabilityDetector/issues/63)) so it will always throw a `ClassNotFoundException`. I'm much less likely to remove `Configurations`, so this should be a safer check to make.