### PR TITLE
Remove duplicate rule from Checkstyle configuration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -40,7 +40,6 @@
 		<module name="RedundantModifier" />
 		<module name="EmptyBlock" />
 		<module name="LeftCurly" />
-		<module name="NeedBraces" />
 		<module name="RightCurly" />
 		<module name="EmptyStatement" />
 		<module name="EqualsHashCode" />


### PR DESCRIPTION
The rule [NeedBraces](http://checkstyle.sourceforge.net/config_blocks.html#NeedBraces) is present twice, on lines [36](https://github.com/JadiraOrg/jadira/blob/19bcb17c57ff838f86c0e2ce27f6129e9149ecbc/checkstyle.xml#L36) and [43](https://github.com/JadiraOrg/jadira/blob/19bcb17c57ff838f86c0e2ce27f6129e9149ecbc/checkstyle.xml#L43), with the same configuration in the `checkstyle.xml` file. The duplicate rule does not provide any useful information but just increases the overhead of Checkstyle.