### PR TITLE
Correctly handle JDK 9 version

### DIFF
--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractParameterizedUserType.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractParameterizedUserType.java
@@ -44,8 +44,7 @@ public abstract class AbstractParameterizedUserType<T, J, C extends ColumnMapper
     
 	private <Z> void doApplyConfiguration() {
 
-	    if (JavaVersion.getMajorVersion() >= 1 &&
-	            JavaVersion.getMinorVersion() >= 8 &&
+	    if (JavaVersion.isJava8OrLater() &&
 	            Jdbc42Configured.class.isAssignableFrom(this.getClass())) {
 	        Jdbc42Configured next = (Jdbc42Configured)this;
 	        performJdbc42Configuration(next);

--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
@@ -75,7 +75,7 @@ public abstract class AbstractUserTypeHibernateIntegrator implements Integrator 
 	    boolean use42Api;
         if (jdbc42Apis == null) {
 
-            if (JavaVersion.getMajorVersion() >= 1 && JavaVersion.getMinorVersion() >= 8) {
+            if (JavaVersion.isJava8OrLater()) {
              
              Connection conn = null;
              try {

--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/utils/runtime/JavaVersion.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/utils/runtime/JavaVersion.java
@@ -1,29 +1,52 @@
 package org.jadira.usertype.spi.utils.runtime;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Provides a convenient capability to retrieve the version of Java
  */
 public class JavaVersion {
 
+    private static final Pattern JDK9_AND_HIGHER = Pattern.compile("([1-9][0-9]*)(\\.(\\d+))?.*");
+
     public static final int MAJOR_VERSION;
     public static final int MINOR_VERSION;
 
     static {
-        String version = System.getProperty("java.version");
-        String[] versions = version.split("[.]");
+        Version version = parseVersion(System.getProperty("java.version"));
+        MAJOR_VERSION = version.major;
+        MINOR_VERSION = version.minor;
+    }
 
-        MAJOR_VERSION = Integer.parseInt(versions[0]);
-        MINOR_VERSION = Integer.parseInt(versions[1]);
+    static Version parseVersion(String version) {
+        if (version.startsWith("1.")) {
+            String[] versions = version.split("\\.");
+            if (versions.length <= 1) {
+                throw new IllegalStateException("Invalid Java version: " + version);
+            }
+            return new Version(1, Integer.parseInt(versions[1]));
+        } else {
+            final Matcher matcher = JDK9_AND_HIGHER.matcher(version);
+            if (matcher.matches()) {
+                int major = Integer.parseInt(matcher.group(1));
+                String minorGroup = matcher.group(3);
+                int minor = minorGroup != null && !minorGroup.isEmpty() ? Integer.parseInt(minorGroup) : 0;
+                return new Version(major, minor);
+            } else {
+                throw new IllegalStateException("Invalid Java version: " + version);
+            }
+        }
     }
 
     public static final int getMajorVersion() {
         return MAJOR_VERSION;
     }
-    
+
     public static final int getMinorVersion() {
         return MINOR_VERSION;
     }
-    
+
     public static boolean isJava8OrLater() {
         if (getMajorVersion() > 1) {
             return true;
@@ -31,6 +54,16 @@ public class JavaVersion {
             return true;
         } else {
             return false;
+        }
+    }
+
+    static class Version {
+        final int major;
+        final int minor;
+
+        Version(int major, int minor) {
+            this.major = major;
+            this.minor = minor;
         }
     }
 }

--- a/usertype.spi/src/test/java/org/jadira/usertype/spi/utils/runtime/JavaVersionTest.java
+++ b/usertype.spi/src/test/java/org/jadira/usertype/spi/utils/runtime/JavaVersionTest.java
@@ -1,0 +1,42 @@
+package org.jadira.usertype.spi.utils.runtime;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class JavaVersionTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"1.7.0_151-b15", new JavaVersion.Version(1, 7)},
+                {"1.8.0_131", new JavaVersion.Version(1, 8)},
+                {"9-ea+73", new JavaVersion.Version(9, 0)},
+                {"9", new JavaVersion.Version(9, 0)},
+                {"9+100", new JavaVersion.Version(9, 0)},
+                {"9.0.1", new JavaVersion.Version(9, 0)},
+                {"9.1.2", new JavaVersion.Version(9, 1)},
+        });
+    }
+
+    private String version;
+    private JavaVersion.Version expected;
+
+    public JavaVersionTest(String version, JavaVersion.Version expected) {
+        this.version = version;
+        this.expected = expected;
+    }
+
+    @Test
+    public void parseJavaVersion() {
+        JavaVersion.Version parsedVersion = JavaVersion.parseVersion(version);
+        assertEquals("Major version mismatch", expected.major, parsedVersion.major);
+        assertEquals("Minor version mismatch", expected.minor, parsedVersion.minor);
+    }
+}


### PR DESCRIPTION
JDK9 changed the naming scheme for Java versions. Instead 1.9 the JRE returns "9" and subsequently "9.0.1", "9.1.2" and so forth.

See http://openjdk.java.net/jeps/223

Fixes #63 