### PR TITLE
Based on hibernate-orm/pull/2076 adding ConcurrentHashMapBackedProperties implmentation

### DIFF
--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
@@ -30,6 +30,7 @@ import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.hibernate.usertype.CompositeUserType;
 import org.hibernate.usertype.UserType;
 import org.jadira.usertype.spi.utils.runtime.JavaVersion;
+import org.hibernate.type.ConcurrentHashMapBackedProperties;
 
 public abstract class AbstractUserTypeHibernateIntegrator implements Integrator {
 

--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
@@ -144,7 +144,7 @@ public abstract class AbstractUserTypeHibernateIntegrator implements Integrator 
 	}
 
 	private void configureDefaultProperties(SessionFactoryImplementor sessionFactory, String javaZone, String databaseZone, String seed, String currencyCode, String jdbc42Apis) {
-		Properties properties = new Properties();
+		ConcurrentHashMapBackedProperties properties = new ConcurrentHashMapBackedProperties();
 		if (databaseZone != null) { properties.put("databaseZone", databaseZone); }
 		if (javaZone != null) { properties.put("javaZone", javaZone); }
 		if (seed != null) { properties.put("seed", seed); }


### PR DESCRIPTION
This is based on [pull request 2076 in hibernate ORM.](https://github.com/hibernate/hibernate-orm/pull/2076)

Since [hibernate-orm/pull/2076](https://github.com/hibernate/hibernate-orm/pull/2076) replaces the implementation of Properties with ConcurrentHashMapBackedProperties for better support of ParameterizedTypes in high concurrency, a likewise change is reflected in jadira's hibernate integrator.