### PR TITLE
Joda Money 1.0 removes deprecated methods that Jadira uses

### DIFF
--- a/depmgmt/pom.xml
+++ b/depmgmt/pom.xml
@@ -274,7 +274,7 @@
 			<dependency>
 				<groupId>org.joda</groupId>
 				<artifactId>joda-money</artifactId>
-				<version>0.12</version>
+				<version>1.0.1</version>
 				<optional>true</optional>
 			</dependency>
 			<dependency>

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrency.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrency.java
@@ -16,6 +16,7 @@
 package org.jadira.usertype.moneyandcurrency.joda;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.jadira.usertype.moneyandcurrency.joda.columnmapper.StringColumnCurrencyUnitMapper;
 import org.jadira.usertype.moneyandcurrency.legacyjdk.columnmapper.BigDecimalBigDecimalColumnMapper;
@@ -29,23 +30,34 @@ import org.joda.money.Money;
  */
 public class PersistentMoneyAmountAndCurrency extends AbstractMultiColumnUserType<Money> {
 
-	private static final long serialVersionUID = 3735995469031558183L;
+    private static final long serialVersionUID = 3735995469031558183L;
 
-	private static final ColumnMapper<?, ?>[] COLUMN_MAPPERS = new ColumnMapper<?, ?>[] { new StringColumnCurrencyUnitMapper(), new BigDecimalBigDecimalColumnMapper() };
+    private static final ColumnMapper<?, ?>[] COLUMN_MAPPERS = new ColumnMapper<?, ?>[] { new StringColumnCurrencyUnitMapper(), new BigDecimalBigDecimalColumnMapper() };
 
     private static final String[] PROPERTY_NAMES = new String[]{ "currencyUnit", "amount" };
-	
-	@Override
-	protected ColumnMapper<?, ?>[] getColumnMappers() {
-		return COLUMN_MAPPERS;
-	}
+
+    private RoundingMode roundingMode;
+
+    public PersistentMoneyAmountAndCurrency() {
+        this(RoundingMode.HALF_UP);
+    }
+
+    public PersistentMoneyAmountAndCurrency(RoundingMode roundingMode) {
+        super();
+        this.roundingMode = roundingMode;
+    }
+
+    @Override
+    protected ColumnMapper<?, ?>[] getColumnMappers() {
+        return COLUMN_MAPPERS;
+    }
 
     @Override
     protected Money fromConvertedColumns(Object[] convertedColumns) {
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         BigDecimal amountPart = (BigDecimal) convertedColumns[1];
-        Money money = Money.of(currencyUnitPart, amountPart);
+        Money money = Money.of(currencyUnitPart, amountPart, roundingMode);
 
         return money;
     }
@@ -55,9 +67,9 @@ public class PersistentMoneyAmountAndCurrency extends AbstractMultiColumnUserTyp
 
         return new Object[] { value.getCurrencyUnit(), value.getAmount() };
     }
-    
+
     @Override
-	public String[] getPropertyNames() {
-		return PROPERTY_NAMES;
-	}
+    public String[] getPropertyNames() {
+        return PROPERTY_NAMES;
+    }
 }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrencyAsInteger.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrencyAsInteger.java
@@ -16,6 +16,7 @@
 package org.jadira.usertype.moneyandcurrency.joda;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.jadira.usertype.moneyandcurrency.joda.columnmapper.IntegerColumnCurrencyUnitMapper;
 import org.jadira.usertype.moneyandcurrency.legacyjdk.columnmapper.BigDecimalBigDecimalColumnMapper;
@@ -35,6 +36,17 @@ public class PersistentMoneyAmountAndCurrencyAsInteger extends AbstractMultiColu
 
     private static final String[] PROPERTY_NAMES = new String[]{ "currencyUnit", "amount" };
 	
+    private RoundingMode roundingMode;
+
+    public PersistentMoneyAmountAndCurrencyAsInteger() {
+        this(RoundingMode.HALF_UP);
+    }
+
+    public PersistentMoneyAmountAndCurrencyAsInteger(RoundingMode roundingMode) {
+        super();
+        this.roundingMode = roundingMode;
+    }
+
 	@Override
 	protected ColumnMapper<?, ?>[] getColumnMappers() {
 		return COLUMN_MAPPERS;
@@ -45,7 +57,7 @@ public class PersistentMoneyAmountAndCurrencyAsInteger extends AbstractMultiColu
 
         CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
         BigDecimal amountPart = (BigDecimal) convertedColumns[1];
-        Money money = Money.of(currencyUnitPart, amountPart);
+        Money money = Money.of(currencyUnitPart, amountPart, roundingMode);
 
         return money;
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnBigMoneyMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnBigMoneyMapper.java
@@ -36,7 +36,7 @@ public class BigDecimalColumnBigMoneyMapper extends AbstractBigDecimalColumnMapp
     @Override
     public BigDecimal toNonNullValue(BigMoney value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return BigMoney.of(value).getAmount();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnMoneyMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnMoneyMapper.java
@@ -36,7 +36,7 @@ public class BigDecimalColumnMoneyMapper extends AbstractBigDecimalColumnMapper<
     @Override
     public BigDecimal toNonNullValue(Money value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return value.getAmount();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/IntegerColumnCurrencyUnitMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/IntegerColumnCurrencyUnitMapper.java
@@ -46,7 +46,7 @@ public class IntegerColumnCurrencyUnitMapper extends AbstractIntegerColumnMapper
 	public String toNonNullString(CurrencyUnit value) {
 		String str = value.getNumeric3Code();
 		if ("".equals(str)) {
-			return value.getCurrencyCode();
+			return value.getCode();
 		} else {
 			return str;
 		}

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnBigMoneyMajorMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnBigMoneyMajorMapper.java
@@ -38,7 +38,7 @@ public class LongColumnBigMoneyMajorMapper extends AbstractLongColumnMapper<BigM
     @Override
     public Long toNonNullValue(BigMoney value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return value.toBigMoney().getAmountMajorLong();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnBigMoneyMinorMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnBigMoneyMinorMapper.java
@@ -34,7 +34,7 @@ public class LongColumnBigMoneyMinorMapper extends AbstractLongColumnMapper<BigM
     @Override
     public Long toNonNullValue(BigMoney value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return value.toBigMoney().getAmountMinorLong();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnMoneyMajorMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnMoneyMajorMapper.java
@@ -34,7 +34,7 @@ public class LongColumnMoneyMajorMapper extends AbstractLongColumnMapper<Money> 
     @Override
     public Long toNonNullValue(Money value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return value.getAmountMajorLong();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnMoneyMinorMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/LongColumnMoneyMinorMapper.java
@@ -34,7 +34,7 @@ public class LongColumnMoneyMinorMapper extends AbstractLongColumnMapper<Money> 
     @Override
     public Long toNonNullValue(Money value) {
     	if (!currencyUnit.equals(value.getCurrencyUnit())) {
-    		throw new IllegalStateException("Expected currency " + currencyUnit.getCurrencyCode() + " but was " + value.getCurrencyUnit());
+    		throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
     	}
         return value.getAmountMinorLong();
     }

--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
@@ -29,6 +29,6 @@ public class StringColumnCurrencyUnitMapper extends AbstractStringColumnMapper<C
 
     @Override
     public String toNonNullValue(CurrencyUnit value) {
-        return value.getCurrencyCode();
+        return value.getCode();
     }
 }

--- a/usertype.core/src/test/java/org/jadira/usertype/moneyandcurrency/joda/TestPersistentCurrencyUnit.java
+++ b/usertype.core/src/test/java/org/jadira/usertype/moneyandcurrency/joda/TestPersistentCurrencyUnit.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 public class TestPersistentCurrencyUnit extends AbstractDatabaseTest<CurrencyUnitHolder> {
 
-    private static final CurrencyUnit[] currencies = new CurrencyUnit[]{CurrencyUnit.EUR, CurrencyUnit.USD, CurrencyUnit.GBP, CurrencyUnit.getInstance("SAR"), null};
+    private static final CurrencyUnit[] currencies = new CurrencyUnit[]{CurrencyUnit.EUR, CurrencyUnit.USD, CurrencyUnit.GBP, CurrencyUnit.of("SAR"), null};
 
     public TestPersistentCurrencyUnit() {
     	super(TestJodaMoneySuite.getFactory());

--- a/usertype.core/src/test/java/org/jadira/usertype/moneyandcurrency/joda/TestPersistentCurrencyUnitAsInteger.java
+++ b/usertype.core/src/test/java/org/jadira/usertype/moneyandcurrency/joda/TestPersistentCurrencyUnitAsInteger.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 public class TestPersistentCurrencyUnitAsInteger extends AbstractDatabaseTest<CurrencyUnitAsIntegerHolder> {
 
-    private static final CurrencyUnit[] currencies = new CurrencyUnit[]{CurrencyUnit.EUR, CurrencyUnit.USD, CurrencyUnit.GBP, CurrencyUnit.getInstance("SAR"), null};
+    private static final CurrencyUnit[] currencies = new CurrencyUnit[]{CurrencyUnit.EUR, CurrencyUnit.USD, CurrencyUnit.GBP, CurrencyUnit.of("SAR"), null};
 
     public TestPersistentCurrencyUnitAsInteger() {
     	super(TestJodaMoneySuite.getFactory());


### PR DESCRIPTION
- Fix #78 Joda Money 1.0 removes deprecated methods that Jadira uses
- The `Money.of()` method without `RoundingMode` throws `ArithmeticException` if the scale exceeds the currency scale. Appending `RoundingMode` excludes `ArithmeticException` in `PersistentMoneyAmountAndCurrency` and `PersistentMoneyAmountAndCurrencyAsInteger`.