### PR TITLE
Update StringColumnCurrencyUnitMapper.java

### DIFF
--- a/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
@@ -29,6 +29,6 @@ public class StringColumnCurrencyUnitMapper extends AbstractStringColumnMapper<C
 
     @Override
     public String toNonNullValue(CurrencyUnit value) {
-        return value.getCurrencyCode();
+        return value.getCode();
     }
 }


### PR DESCRIPTION
CurrencyUnit class in joda money has not any method getCurrencyCode()
so, must use value.getCode(); instead of value.getCurrencyCode();
getCurrencyCode() method exist in Currency class, and  CurrencyUnit class have getCode() method