### PR TITLE
Fixes TimeColumnLocalTimeMapper

### DIFF
--- a/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimeColumnLocalTimeMapper.java
+++ b/usertype.core/src/main/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimeColumnLocalTimeMapper.java
@@ -15,19 +15,16 @@
  */
 package org.jadira.usertype.dateandtime.threeten.columnmapper;
 
-import java.sql.Time;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-
 import org.jadira.usertype.spi.shared.AbstractTimeColumnMapper;
 
-public class TimeColumnLocalTimeMapper extends AbstractTimeColumnMapper<LocalTime> {
+import java.sql.Time;
+import java.time.LocalTime;
+
+public class TimeColumnLocalTimeMapper extends AbstractTimeColumnMapper<LocalTime>
+{
 
     private static final long serialVersionUID = 6734385103313158326L;
-    
-    public static final DateTimeFormatter LOCAL_TIME_FORMATTER = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss").toFormatter();
+        
 
 	public TimeColumnLocalTimeMapper() {
 	}
@@ -49,13 +46,8 @@ public class TimeColumnLocalTimeMapper extends AbstractTimeColumnMapper<LocalTim
     }
 
     @Override
-    public Time toNonNullValue(LocalTime value) {
-    	
-    	LocalDateTime localDateTime = LocalDateTime.of(
-    				1970, 1, 1, value.getHour(), value.getMinute(), value.getSecond(), value.getNano()
-    			);
-    	
-        final Time time = new Time(localDateTime.getNano());
-        return time;
+    public Time toNonNullValue(LocalTime value)
+    {
+        return Time.valueOf(value);
     }
 }

--- a/usertype.core/src/test/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimeColumnLocalTimeMapperTest.java
+++ b/usertype.core/src/test/java/org/jadira/usertype/dateandtime/threeten/columnmapper/TimeColumnLocalTimeMapperTest.java
@@ -1,0 +1,28 @@
+package org.jadira.usertype.dateandtime.threeten.columnmapper;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+import static org.junit.Assert.*;
+
+public class TimeColumnLocalTimeMapperTest
+{
+  private TimeColumnLocalTimeMapper timeColumnLocalTimeMapper;
+
+  @Before
+  public void setup()
+  {
+    timeColumnLocalTimeMapper = new TimeColumnLocalTimeMapper();
+  }
+  @Test
+  public void toNonNullValueShouldReturnTheCorrectTime()
+  {
+    LocalTime localTime = LocalTime.of(13, 37);
+    Time expected = Time.valueOf("13:37:00");
+    Time time = timeColumnLocalTimeMapper.toNonNullValue(localTime);
+    assertEquals(expected, time);
+  }
+}


### PR DESCRIPTION
It was not parsing LocalDate (java 8) to java.sql.Time correctly. issue #70 