### PR TITLE
Fix connection leak by releasing the obtained connection properly

### DIFF
--- a/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
+++ b/usertype.spi/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
@@ -78,8 +78,8 @@ public abstract class AbstractUserTypeHibernateIntegrator implements Integrator 
             if (JavaVersion.isJava8OrLater()) {
              
              Connection conn = null;
+             JdbcServices jdbcServices = sessionFactory.getServiceRegistry().getService(JdbcServices.class);
              try {
-                    JdbcServices jdbcServices = sessionFactory.getServiceRegistry().getService(JdbcServices.class);
                     conn = jdbcServices.getBootstrapJdbcConnectionAccess().obtainConnection();
                     
                     DatabaseMetaData dmd = conn.getMetaData();
@@ -102,7 +102,7 @@ public abstract class AbstractUserTypeHibernateIntegrator implements Integrator 
                     
                     if (conn != null) {
                         try {
-                            conn.close();
+                            jdbcServices.getBootstrapJdbcConnectionAccess().releaseConnection(conn);
                         } catch (SQLException e) {
                             // Ignore
                         }


### PR DESCRIPTION
This PR fixes a connection leak that happens when checking the driver version in order to determine if JDBC 4.2 APIs should be used or not by the Hibernate integrators.

The connection was obtained through `obtainConnection()`, but was not properly released, as invoking `close()` doesn't actually make the connection available in the connection pool. Calling `releaseConnection()` on the other side follows the correct process for releasing the resources and this way the connection pool stays balanced and there are no leaks. The closing of the connection is then [handled by Hibernate](https://github.com/hibernate/hibernate-orm/blob/cc42864351ab571cd1b85347fdc323764a35fa30/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java#L466-L478).

A workaround for the existing connection leak is providing the `jadira.usertype.useJdbc42Apis` system property. Either value (`true` or `false`) will make the above check unnecessary and a connection will not be obtained.